### PR TITLE
Smdtesting

### DIFF
--- a/include/smd.h
+++ b/include/smd.h
@@ -27,8 +27,8 @@ struct smd_attr_t{
 	void 				* value; // if value != NULL, we are the owner of the data
 	int id;
 
-	int children; // number of child attributes
-	int childSlots;
+	unsigned int children; // number of child attributes
+	unsigned int childSlots;
 	smd_attr_t * parent;
   smd_attr_t ** childs;
 };
@@ -62,7 +62,7 @@ typedef enum{
  */
 smd_link_ret_t smd_attr_link(smd_attr_t * parent, smd_attr_t * child, int allow_replace);
 
-void smd_attr_unlink_pos(smd_attr_t * parent, int pos);
+void smd_attr_unlink_pos(smd_attr_t * parent, unsigned int pos);
 
 /**
  * Retrieve a position for an attribute to manipulate the attribute
@@ -70,7 +70,7 @@ void smd_attr_unlink_pos(smd_attr_t * parent, int pos);
 int smd_find_position_by_id(const smd_attr_t * attr, int id);
 int smd_find_position_by_name(const smd_attr_t * attr, const char * name);
 
-smd_attr_t * smd_attr_get_child  (const smd_attr_t * attr, int pos);
+smd_attr_t * smd_attr_get_child  (const smd_attr_t * attr, unsigned int pos);
 
 /**
  * The function copies the value of the attribute into the pointer of out_val

--- a/src/smd-core.c
+++ b/src/smd-core.c
@@ -4,6 +4,7 @@
 
 #include <smd-internal.h>
 
+
 #define use_type_ptr(t) (t->type < SMD_TYPE_PRIMITIVE_END || (t->type == SMD_TYPE_EXTENT && t->specifier.u.ext.base->type < SMD_TYPE_PRIMITIVE_END))
 
 // Native Datatypes ///////////////////////////////////////////////////////////
@@ -163,8 +164,8 @@ static void smd_attr_copy_val_to_internal(char * out, smd_dtype_t * t, const voi
 				smd_dtype_array_t * d = & t->specifier.u.arr;
 				char * val_pos = (char*) val;
 				char * out_pos = (char*) out;
-				for(int i=0; i < d->count; i++){
-					smd_attr_copy_val_to_internal(out_pos, d->base, *(char**)val_pos);
+				for(u_int64_t i=0; i < d->count; i++){
+					smd_attr_copy_val_to_internal(out_pos, d->base, val_pos);
 					out_pos += d->base->size;
 					val_pos += d->base->extent;
 				}
@@ -248,7 +249,7 @@ static void smd_attr_copy_val_to_external(char * out, smd_dtype_t * t, char * va
 				smd_dtype_array_t * d = & t->specifier.u.arr;
 				char * val_pos = val;
 				char * out_pos = (char*) out;
-				for(int i=0; i < d->count; i++){
+				for(u_int64_t i=0; i < d->count; i++){
 					smd_attr_copy_val_to_external(out_pos, d->base, val_pos);
 					out_pos += d->base->extent;
 					val_pos += d->base->size;
@@ -511,7 +512,7 @@ static size_t smd_attr_ser_json_val(char * buff, void * val, smd_dtype_t * t){
 				if( d->count > 0 ){
 					buff += smd_attr_ser_json_val(buff, val_pos, d->base);
 					val_pos += d->base->size;
-					for(int i=1; i < d->count; i++){
+					for(u_int64_t i=1; i < d->count; i++){
 						buff += sprintf(buff, ",");
 						buff += smd_attr_ser_json_val(buff, val_pos, d->base);
 						val_pos += d->base->size;
@@ -715,7 +716,7 @@ static char * smd_attr_val_from_json(char * val, smd_dtype_t * t, char * str){
 				if(*str != '[') return NULL;
 				str++;
 				if( d->count > 0 ){
-					for(int i=0; i < d->count; i++){
+					for(u_int64_t i=0; i < d->count; i++){
 						if(i > 0){
 							if(*str != ',') return NULL;
 							str++;

--- a/src/smd-core.c
+++ b/src/smd-core.c
@@ -164,7 +164,7 @@ static void smd_attr_copy_val_to_internal(char * out, smd_dtype_t * t, const voi
 				smd_dtype_array_t * d = & t->specifier.u.arr;
 				char * val_pos = (char*) val;
 				char * out_pos = (char*) out;
-				for(u_int64_t i=0; i < d->count; i++){
+				for(uint64_t i=0; i < d->count; i++){
 					smd_attr_copy_val_to_internal(out_pos, d->base, val_pos);
 					out_pos += d->base->size;
 					val_pos += d->base->extent;
@@ -249,7 +249,7 @@ static void smd_attr_copy_val_to_external(char * out, smd_dtype_t * t, char * va
 				smd_dtype_array_t * d = & t->specifier.u.arr;
 				char * val_pos = val;
 				char * out_pos = (char*) out;
-				for(u_int64_t i=0; i < d->count; i++){
+				for(uint64_t i=0; i < d->count; i++){
 					smd_attr_copy_val_to_external(out_pos, d->base, val_pos);
 					out_pos += d->base->extent;
 					val_pos += d->base->size;
@@ -514,7 +514,7 @@ static size_t smd_attr_ser_json_val(char * buff, void * val, smd_dtype_t * t){
 				if( d->count > 0 ){
 					buff += smd_attr_ser_json_val(buff, val_pos, d->base);
 					val_pos += d->base->size;
-					for(u_int64_t i=1; i < d->count; i++){
+					for(uint64_t i=1; i < d->count; i++){
 						buff += sprintf(buff, ",");
 						buff += smd_attr_ser_json_val(buff, val_pos, d->base);
 						val_pos += d->base->size;
@@ -718,7 +718,7 @@ static char * smd_attr_val_from_json(char * val, smd_dtype_t * t, char * str){
 				if(*str != '[') return NULL;
 				str++;
 				if( d->count > 0 ){
-					for(u_int64_t i=0; i < d->count; i++){
+					for(uint64_t i=0; i < d->count; i++){
 						if(i > 0){
 							if(*str != ',') return NULL;
 							str++;

--- a/src/smd-core.c
+++ b/src/smd-core.c
@@ -143,7 +143,7 @@ static void smd_attr_copy_val_to_internal(char * out, smd_dtype_t * t, const voi
 			  break;
 			}case(SMD_TYPE_STRING):{
 				char ** p = (char **) out;
-				*p = strdup((char*) val);
+				*p = strdup(*(char**) val);
 				//printf("STR %lld: %s %ld = %s\n", out, val, val, *((char**)out));
 				break;
 			}case(SMD_TYPE_EXTENT):{
@@ -312,7 +312,9 @@ smd_attr_t * smd_attr_new(const char* name, smd_dtype_t * type, const void * val
 
 	if(val != NULL){
 		smd_dtype_t * t = attr->type;
-		if(use_type_ptr(t)){
+		if(type->type == SMD_TYPE_STRING){
+			attr->value = strdup((char*) val);
+		}else if(use_type_ptr(t)){
 			smd_attr_copy_val_to_internal((char*) & attr->value, type, val);
 		}else{
 			smd_attr_alloc(& attr->value, type);

--- a/src/smd-core.c
+++ b/src/smd-core.c
@@ -60,7 +60,7 @@ char * smd_dup_escaped_varname(const char * name){
 }
 
 int smd_find_position_by_name(const smd_attr_t * attr, const char * name){
-	for(int i=0; i < attr->children; i++){
+	for(unsigned  int i=0; i < attr->children; i++){
 		if(strcmp(attr->childs[i]->name, name) == 0){
 			return i;
 		}
@@ -69,7 +69,7 @@ int smd_find_position_by_name(const smd_attr_t * attr, const char * name){
 }
 
 int smd_find_position_by_id(const smd_attr_t * attr, int id){
-	for(int i=0; i < attr->children; i++){
+	for(unsigned int i=0; i < attr->children; i++){
 		if(attr->childs[i]->id == id){
 			return i;
 		}
@@ -326,8 +326,8 @@ smd_attr_t * smd_attr_new(const char* name, smd_dtype_t * type, const void * val
 	return attr;
 }
 
-void smd_attr_unlink_pos(smd_attr_t * p, int pos){
-	assert(p->children > pos && pos >= 0);
+void smd_attr_unlink_pos(smd_attr_t * p, unsigned int pos){
+	assert(p->children > pos);
 	smd_attr_t * c = p->childs[pos];
 	c->parent = NULL;
 
@@ -358,7 +358,7 @@ smd_link_ret_t smd_attr_link(smd_attr_t * parent, smd_attr_t * child, int allow_
 			// need to extend the existing structure
 			parent->childSlots *= 2;
 			smd_attr_t ** new = malloc(sizeof(void*) * parent->childSlots);
-			for(int i=0; i < parent->children; i++){
+			for(unsigned int i=0; i < parent->children; i++){
 				new[i] = parent->childs[i];
 			}
 			free(parent->childs);
@@ -545,7 +545,7 @@ static size_t smd_attr_ser_json_i(char * buff, smd_attr_t * attr){
 	if(attr->children){
 		buff += sprintf(buff, ",\"childs\":{");
 		buff += smd_attr_ser_json_i(buff, attr->childs[0]);
-		for(int i=1; i < attr->children; i++){
+		for(unsigned int i=1; i < attr->children; i++){
 			buff += sprintf(buff, ",");
 			buff += smd_attr_ser_json_i(buff, attr->childs[i]);
 		}
@@ -809,14 +809,14 @@ smd_attr_t * smd_attr_create_from_json(char * str){
 
 void smd_iterate(smd_attr_t * attr, void (*iter)(int id, const char*name)){
 	iter(attr->id, attr->name);
-	for(int i=0; i < attr->children; i++){
+	for(unsigned int i=0; i < attr->children; i++){
 		smd_iterate(attr->childs[i], iter);
 	}
 }
 
 void smd_attr_destroy(smd_attr_t * attr){
 	if(attr->childs){
-		for(int i=0; i < attr->children; i++){
+		for(unsigned int i=0; i < attr->children; i++){
 			smd_attr_destroy(attr->childs[i]);
 		}
 		free(attr->childs);
@@ -848,7 +848,7 @@ int    smd_attr_count    (const smd_attr_t * attr){
   return attr->children;
 }
 
-smd_attr_t * smd_attr_get_child  (const smd_attr_t * attr, int child){
-  assert(attr->children > child && child >= 0);
+smd_attr_t * smd_attr_get_child  (const smd_attr_t * attr, unsigned int child){
+  assert(attr->children > child);
   return attr->childs[child];
 }

--- a/src/smd-core.c
+++ b/src/smd-core.c
@@ -324,7 +324,7 @@ smd_attr_t * smd_attr_new(const char* name, smd_dtype_t * type, const void * val
 }
 
 void smd_attr_unlink_pos(smd_attr_t * p, int pos){
-	assert(p->children > pos);
+	assert(p->children > pos && pos >= 0);
 	smd_attr_t * c = p->childs[pos];
 	c->parent = NULL;
 
@@ -846,6 +846,6 @@ int    smd_attr_count    (const smd_attr_t * attr){
 }
 
 smd_attr_t * smd_attr_get_child  (const smd_attr_t * attr, int child){
-  assert(child < attr->children);
+  assert(attr->children > child && child >= 0);
   return attr->childs[child];
 }


### PR DESCRIPTION
- Removed the pointer casting for array in copy_val_to_internal so that creating attributes for arrays work.
- Added check for negative numbers in pos arguments.
- Changed data type of some iterators to match type in test condition.
